### PR TITLE
Add CI circuit checks for Gnark, Noir, and RISC0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  gnark-circuit:
+    name: gnark circuit checks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: gnark
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: gnark/go.mod
+          cache-dependency-path: gnark/go.sum
+
+      - name: Check formatting
+        run: test -z "$(gofmt -l $(find src -type f -name '*.go'))"
+
+      - name: Run static checks
+        run: go vet ./src
+
+      - name: Check circuit constraints
+        run: go test ./src -run '^TestCircuitScenarios$' -count=1 -timeout 10m
+
+  noir-circuit:
+    name: Noir circuit checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Compile and execute Noir circuit
+        env:
+          ZKGUARD_NOIR_PROVE: "0"
+        run: ./scripts/runners/run-noir-contributor-payments.sh
+
+  risc0-circuit:
+    name: RISC0 circuit checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Execute RISC0 guest in dev mode
+        env:
+          RISC0_DEV_MODE: "1"
+        run: ./scripts/runners/run-risc0-contributor-payments.sh

--- a/gnark/src/circuit_test.go
+++ b/gnark/src/circuit_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/consensys/gnark/test"
+)
+
+func TestCircuitScenarios(t *testing.T) {
+	scenarios := []string{
+		"contributor_payments",
+		"defi_swaps",
+		"supply_lending",
+		"amount_limits",
+		"function_level_controls",
+		"interact_dapps",
+		"advanced_signer_policies",
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario, func(t *testing.T) {
+			assignment, err := getExampleAssignment(scenario)
+			if err != nil {
+				t.Fatalf("build assignment: %v", err)
+			}
+
+			var circuit ZKGuardCircuit
+			if err := test.IsSolved(&circuit, &assignment, ecc.BN254.ScalarField()); err != nil {
+				t.Fatalf("circuit constraints are not satisfied: %v", err)
+			}
+		})
+	}
+}

--- a/scripts/runners/run-noir-contributor-payments.sh
+++ b/scripts/runners/run-noir-contributor-payments.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 docker run --rm \
+  -e ZKGUARD_NOIR_PROVE="${ZKGUARD_NOIR_PROVE:-1}" \
   -v "$REPO_ROOT:/repo:ro" \
   ubuntu:24.04 \
   bash -lc '
@@ -12,13 +13,16 @@ docker run --rm \
     DEBIAN_FRONTEND=noninteractive apt-get install -y curl git jq xz-utils python3 python3-pip python3-venv >/dev/null
     cp -a /repo /tmp/zkguard
     cd /tmp/zkguard/noir
+    NOIR_PROVE="${ZKGUARD_NOIR_PROVE:-1}"
 
     curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash >/dev/null
-    curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash >/dev/null
     export PATH="$PATH:/root/.nargo/bin"
     noirup -v 1.0.0-beta.13 >/dev/null
-    export PATH="$PATH:/root/.bb"
-    bbup -v 0.87.0 >/dev/null
+    if [ "$NOIR_PROVE" != "0" ]; then
+      curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash >/dev/null
+      export PATH="$PATH:/root/.bb"
+      bbup -v 0.87.0 >/dev/null
+    fi
 
     python3 -m venv /tmp/noir-venv
     /tmp/noir-venv/bin/pip install -q -r requirements.txt
@@ -26,7 +30,9 @@ docker run --rm \
 
     nargo compile
     nargo execute
-    bb write_vk -b ./target/zkguard.json -o target
-    bb prove -b ./target/zkguard.json -w ./target/zkguard.gz -o target
-    bb verify -p ./target/proof -k ./target/vk -i ./target/public_inputs
+    if [ "$NOIR_PROVE" != "0" ]; then
+      bb write_vk -b ./target/zkguard.json -o target
+      bb prove -b ./target/zkguard.json -w ./target/zkguard.gz -o target
+      bb verify -p ./target/proof -k ./target/vk -i ./target/public_inputs
+    fi
   '

--- a/scripts/runners/run-risc0-contributor-payments.sh
+++ b/scripts/runners/run-risc0-contributor-payments.sh
@@ -9,7 +9,7 @@ SMOKE_LOG="$ARTIFACT_DIR/risc0-contributor_payments.log"
 HOST_CACHE="/tmp/risc0-host"
 CARGO_HOME="$HOST_CACHE/cargo-home"
 RUSTUP_HOME="$HOST_CACHE/rustup-home"
-RZUP_HOME="/home/clawd/.risc0"
+RISC0_HOME="${RISC0_HOME:-${HOME}/.risc0}"
 DEV_MODE="${RISC0_DEV_MODE:-0}"
 
 mkdir -p "$ARTIFACT_DIR"
@@ -19,8 +19,8 @@ if [ ! -x "$CARGO_HOME/bin/rzup" ]; then
   docker run --rm -v "$HOST_CACHE:/out" rust:1.91 bash -lc "cp -a /usr/local/cargo /out/cargo-home && cp -a /usr/local/rustup /out/rustup-home"
 fi
 
-if [ ! -x "$RZUP_HOME/extensions/v3.0.5-cargo-risczero-x86_64-unknown-linux-gnu/r0vm" ]; then
-  export CARGO_HOME RUSTUP_HOME RZUP_HOME
+if [ ! -x "$RISC0_HOME/extensions/v3.0.5-cargo-risczero-x86_64-unknown-linux-gnu/r0vm" ]; then
+  export CARGO_HOME RUSTUP_HOME RISC0_HOME
   export PATH="$CARGO_HOME/bin:$PATH"
   cargo install rzup --locked
   rzup install
@@ -39,8 +39,8 @@ fi
 
 (
   cd "$RISC0_ROOT"
-  export CARGO_HOME RUSTUP_HOME RZUP_HOME
-  export PATH="$CARGO_HOME/bin:$RZUP_HOME/extensions/v3.0.5-cargo-risczero-x86_64-unknown-linux-gnu:$PATH"
+  export CARGO_HOME RUSTUP_HOME RISC0_HOME
+  export PATH="$CARGO_HOME/bin:$RISC0_HOME/extensions/v3.0.5-cargo-risczero-x86_64-unknown-linux-gnu:$PATH"
   export RISC0_THREADS="${RISC0_THREADS:-2}"
   cargo build --release --example prover
   ./target/release/examples/prover \


### PR DESCRIPTION
## What changed

Adds GitHub Actions CI for the three ZKGuard implementations.

- Gnark checks all seven scenarios with `gnark/test.IsSolved`, without Groth16 proof generation.
- Noir runs `nargo compile` and `nargo execute`, skipping Barretenberg proving and verification.
- RISC0 runs the existing contributor-payment flow in dev mode and verifies the development receipt.
- Runner changes make Noir proving optional and RISC0 tool installation portable across local and GitHub runner homes.

## Validation

- Gnark circuit scenarios passed.
- Noir compile and witness execution passed.
- RISC0 dev-mode execution and verification passed.
- Shell syntax and diff checks passed.

Production proof generation remains outside required pull-request CI.