### PR TITLE
[codex] Add typed Lean policy specification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,17 @@ jobs:
         env:
           RISC0_DEV_MODE: "1"
         run: ./scripts/runners/run-risc0-contributor-payments.sh
+
+  lean-spec:
+    name: Lean specification checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build specification
+        uses: leanprover/lean-action@v1
+        with:
+          lake-package-directory: spec/lean
+          build: true
+          test: false

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ paper/*.pdf
 
 # Local harness / orchestration residue. Keep out of the public repo.
 .cache/
+spec/lean/.lake/
 AGENTS.md
 docs/
 SPEC.md

--- a/spec/lean/ZkGuard.lean
+++ b/spec/lean/ZkGuard.lean
@@ -1,0 +1,7 @@
+import ZkGuard.Types
+import ZkGuard.Semantics
+import ZkGuard.Properties
+import ZkGuard.Profiles.Noir
+import ZkGuard.Examples
+
+/-! # ZKGuard typed executable specification -/

--- a/spec/lean/ZkGuard/Examples.lean
+++ b/spec/lean/ZkGuard/Examples.lean
@@ -1,0 +1,124 @@
+import ZkGuard.Properties
+
+/-!
+# Executable examples spanning the base compliance algorithm
+-/
+
+namespace ZkGuard.Examples
+
+open ZkGuard
+
+def address (n : Nat) : Address := ⟨n % (2 ^ 160), Nat.mod_lt _ (by decide)⟩
+def amount (n : Nat) : Amount := ⟨n % (2 ^ 256), Nat.mod_lt _ (by decide)⟩
+
+def owner := address 0x100
+def recipient := address 0x200
+def token := address 0x300
+def dex := address 0x400
+
+def context : Context := {
+  groups := [("Owners", [owner]), ("Recipients", [recipient])]
+  allowlists := [("Dexes", [dex])]
+}
+
+def baseAction : Action := {
+  initiator := address 0x500
+  to := token
+  value := 0
+  nonce := 0
+  data := []
+}
+
+def transferData (to : Address) (value : Amount) : List Byte :=
+  natToBytesBE 4 transferSelector.val ++
+  natToBytesBE 32 to.val ++
+  natToBytesBE 32 value.val
+
+def transferRule : Rule := {
+  id := 1
+  txType := .transfer
+  destination := .group "Recipients"
+  signer := .exact owner
+  asset := .exact token
+  amountMax := some (amount 100)
+  functionSelector := none
+}
+
+def authFor (action : Action) (slots : List AuthSlot) : Authentication :=
+  .forAction action slots
+
+example :
+    let action := { baseAction with data := transferData recipient (amount 100) }
+    transferRule.complies context action (authFor action [.valid owner]) = true := by native_decide
+
+example :
+    let action := { baseAction with data := transferData recipient (amount 101) }
+    transferRule.complies context action (authFor action [.valid owner]) = false := by native_decide
+
+example :
+    let action := { baseAction with data := transferData recipient (amount 100) }
+    transferRule.complies context action (authFor action [.invalid]) = false := by native_decide
+
+def callRule : Rule := {
+  id := 2
+  txType := .contractCall
+  destination := .allowlist "Dexes"
+  signer := .threshold "Owners" 1
+  asset := .any
+  amountMax := none
+  functionSelector := some ⟨0x12345678, by decide⟩
+}
+
+example :
+    let action := { baseAction with to := dex, data := natToBytesBE 4 0x12345678 }
+    callRule.complies context action (authFor action [.valid owner, .valid owner]) = true := by
+  native_decide
+
+example :
+    signerMatches context baseAction (.threshold "Owners" 2)
+      (authFor baseAction [.valid owner, .valid owner]) = false := by
+  native_decide
+
+example :
+    let action := { baseAction with to := dex, data := natToBytesBE 4 0x87654321 }
+    callRule.complies context action (authFor action [.valid owner]) = false := by native_decide
+
+example : signerMatches context baseAction .any (authFor baseAction [.valid owner]) = true := by
+  native_decide
+example : signerMatches context baseAction (.group "Owners")
+    (authFor baseAction [.valid owner]) = true := by native_decide
+example : destinationMatches context (.exact dex) dex = true := by native_decide
+example : destinationMatches context (.group "Recipients") recipient = true := by native_decide
+example : destinationMatches context (.allowlist "Missing") dex = false := by native_decide
+example : assetMatches .any token = true := by native_decide
+example : context.wellFormed = true := by native_decide
+
+example :
+    let ambiguous : Context := {
+      groups := [("Owners", [owner]), ("Owners", [recipient])]
+      allowlists := []
+    }
+    transferRule.complies ambiguous baseAction (authFor baseAction [.valid owner]) = false := by
+  native_decide
+
+example :
+    let action := { baseAction with data := transferData recipient (amount 100) }
+    evaluate ⟨[transferRule]⟩ context action (authFor action [.valid owner]) =
+      .allow transferRule.id := by native_decide
+
+example :
+    let action := { baseAction with data := transferData recipient (amount 101) }
+    evaluate ⟨[transferRule]⟩ context action (authFor action [.valid owner]) = .deny := by
+  native_decide
+
+example :
+    classify { baseAction with to := recipient, value := amount 7, data := [] } =
+      .ok { txType := .transfer, destination := recipient, asset := zeroAddress, amount := amount 7 } := by
+  rfl
+
+example :
+    classify { baseAction with value := amount 7, data := [0] } =
+      .error .nativeValueWithCalldata := by
+  rfl
+
+end ZkGuard.Examples

--- a/spec/lean/ZkGuard/Profiles/Noir.lean
+++ b/spec/lean/ZkGuard/Profiles/Noir.lean
@@ -1,0 +1,216 @@
+import ZkGuard.Semantics
+
+/-!
+# Noir commitment profiles
+
+The policy decision is always `Rule.complies`. This profile describes only the
+canonical encodings and public authentication of a rule. It does not model
+compiled ACIR constraints or claim implementation conformance; that separate
+bridge requires conformance vectors and differential execution. Noir V1 used a
+SHA-256 Merkle membership path, while Noir V2 commits directly to one canonical
+rule with Poseidon2.
+-/
+
+namespace ZkGuard.Profiles.Noir
+
+open ZkGuard
+
+abbrev Digest256 := Fin (2 ^ 256)
+
+def bn254ScalarModulus : Nat :=
+  21888242871839275222246405745257275088548364400416034343698204186575808495617
+
+abbrev Scalar := Fin bn254ScalarModulus
+
+structure Primitives where
+  sha256 : List Byte → Digest256
+  sha256Pair : Digest256 → Digest256 → Digest256
+  nameHash : SetName → Scalar
+  poseidon2 : List Scalar → Scalar
+
+def scalarOfNat (n : Nat) : Scalar :=
+  ⟨n % bn254ScalarModulus, Nat.mod_lt _ (by decide)⟩
+
+def scalarOfAddress (address : Address) : Scalar := scalarOfNat address.val
+def scalarOfSelector (selector : Selector) : Scalar := scalarOfNat selector.val
+def scalarOfAmount (amount : Amount) : Scalar := scalarOfNat amount.val
+def scalarOfBool (value : Bool) : Scalar := if value then scalarOfNat 1 else scalarOfNat 0
+
+def txTypeTag : TxType → Scalar
+  | .transfer => scalarOfNat 0
+  | .contractCall => scalarOfNat 1
+
+def destinationFields (primitives : Primitives) : DestinationPattern → Scalar × Scalar × Scalar
+  | .any => (scalarOfNat 0, scalarOfNat 0, scalarOfNat 0)
+  | .group name => (scalarOfNat 1, primitives.nameHash name, scalarOfNat 0)
+  | .allowlist name => (scalarOfNat 2, primitives.nameHash name, scalarOfNat 0)
+  | .exact address => (scalarOfNat 3, scalarOfNat 0, scalarOfAddress address)
+
+def signerFields (primitives : Primitives) : SignerPattern → Scalar × Scalar × Scalar × Scalar
+  | .any => (scalarOfNat 0, scalarOfNat 0, scalarOfNat 0, scalarOfNat 0)
+  | .exact address =>
+      (scalarOfNat 1, scalarOfAddress address, scalarOfNat 0, scalarOfNat 0)
+  | .group name =>
+      (scalarOfNat 2, scalarOfNat 0, primitives.nameHash name, scalarOfNat 0)
+  | .threshold group required =>
+      (scalarOfNat 3, scalarOfNat 0, primitives.nameHash group, scalarOfNat required)
+
+def assetFields : AssetPattern → Scalar × Scalar
+  | .any => (scalarOfNat 0, scalarOfNat 0)
+  | .exact address => (scalarOfNat 1, scalarOfAddress address)
+
+/- Exact 14-field preimage used by the optimized Noir circuit. `Rule.id` is
+intentionally absent because the current Noir circuit does not commit to it.
+-/
+def v2PolicyPreimage (primitives : Primitives) (rule : Rule) : List Scalar :=
+  let (destinationTag, destinationName, destinationAddress) :=
+    destinationFields primitives rule.destination
+  let (signerTag, signerAddress, signerGroup, threshold) :=
+    signerFields primitives rule.signer
+  let (assetTag, assetAddress) := assetFields rule.asset
+  let (hasAmount, amount) :=
+    match rule.amountMax with
+    | none => (false, scalarOfNat 0)
+    | some maximum => (true, scalarOfAmount maximum)
+  let (hasSelector, selector) :=
+    match rule.functionSelector with
+    | none => (false, scalarOfNat 0)
+    | some value => (true, scalarOfSelector value)
+  [ txTypeTag rule.txType,
+    destinationTag, destinationName, destinationAddress,
+    signerTag, signerAddress, signerGroup, threshold,
+    assetTag, assetAddress,
+    scalarOfBool hasAmount, amount,
+    scalarOfBool hasSelector, selector ]
+
+def v2PolicyCommitment (primitives : Primitives) (rule : Rule) : Scalar :=
+  primitives.poseidon2 (v2PolicyPreimage primitives rule)
+
+def bytes32 (value : Nat) : List Byte := natToBytesBE 32 value
+def bytes20 (value : Nat) : List Byte := natToBytesBE 20 value
+def bytes4 (value : Nat) : List Byte := natToBytesBE 4 value
+def byte1 (value : Nat) : List Byte := natToBytesBE 1 value
+
+/- Exact 291-byte canonical leaf encoding used by Noir V1. Like V2, V1 did
+not include `Rule.id` in its leaf serialization.
+-/
+def v1PolicyLeafBytes (primitives : Primitives) (rule : Rule) : List Byte :=
+  let (destinationTag, destinationName, destinationAddress) :=
+    destinationFields primitives rule.destination
+  let (signerTag, signerAddress, signerGroup, threshold) :=
+    signerFields primitives rule.signer
+  let (assetTag, assetAddress) := assetFields rule.asset
+  let (hasAmount, amount) :=
+    match rule.amountMax with
+    | none => (false, scalarOfNat 0)
+    | some maximum => (true, scalarOfAmount maximum)
+  let (hasSelector, selector) :=
+    match rule.functionSelector with
+    | none => (false, scalarOfNat 0)
+    | some value => (true, scalarOfSelector value)
+  bytes32 (txTypeTag rule.txType).val ++
+  bytes32 destinationTag.val ++ bytes32 destinationName.val ++ bytes20 destinationAddress.val ++
+  bytes32 signerTag.val ++ bytes20 signerAddress.val ++ bytes32 signerGroup.val ++ byte1 threshold.val ++
+  bytes32 assetTag.val ++ bytes20 assetAddress.val ++
+  byte1 (if hasAmount then 1 else 0) ++ bytes32 amount.val ++
+  byte1 (if hasSelector then 1 else 0) ++ bytes4 selector.val
+
+structure MerklePath where
+  leafIndex : Nat
+  siblings : List Digest256
+  deriving Repr, DecidableEq
+
+def merkleRootFromPath
+    (primitives : Primitives) (leaf : Digest256) (path : MerklePath) : Digest256 :=
+  (path.siblings.foldl
+    (fun (state : Digest256 × Nat) sibling =>
+      let (current, index) := state
+      let parent :=
+        if index % 2 == 0 then
+          primitives.sha256Pair current sibling
+        else
+          primitives.sha256Pair sibling current
+      (parent, index / 2))
+    (leaf, path.leafIndex)).1
+
+def v1Authenticates
+    (primitives : Primitives) (root : Digest256) (rule : Rule) (path : MerklePath) : Bool :=
+  decide (path.leafIndex < 2 ^ path.siblings.length) &&
+  merkleRootFromPath primitives (primitives.sha256 (v1PolicyLeafBytes primitives rule)) path == root
+
+def v2Authenticates
+    (primitives : Primitives) (claimedPolicyHash : Scalar) (rule : Rule) : Bool :=
+  v2PolicyCommitment primitives rule == claimedPolicyHash
+
+def collisionFreeNameHashes (primitives : Primitives) : List SetName → Bool
+  | [] => true
+  | name :: rest =>
+      rest.all (fun other => name == other || !(primitives.nameHash name == primitives.nameHash other)) &&
+      collisionFreeNameHashes primitives rest
+
+def destinationGroupNames : DestinationPattern → List SetName
+  | .group name => [name]
+  | _ => []
+
+def destinationAllowlistNames : DestinationPattern → List SetName
+  | .allowlist name => [name]
+  | _ => []
+
+def signerGroupNames : SignerPattern → List SetName
+  | .group name => [name]
+  | .threshold name _ => [name]
+  | _ => []
+
+/- Noir currently has no nonce input, so its profile only represents the
+canonical zero-nonce subset. Values parsed as fields must fit BN254 exactly.
+-/
+def compatible (primitives : Primitives) (rule : Rule) (context : Context) (action : Action)
+    (authentication : Authentication) : Bool :=
+  let groupEntries := context.groups.foldl (fun total entry => total + entry.2.length) 0
+  let allowlistEntries := context.allowlists.foldl (fun total entry => total + entry.2.length) 0
+  let thresholdFits :=
+    match rule.signer with
+    | .threshold _ required => required < 256
+    | _ => true
+  let erc20AmountFits :=
+    match parseErc20Transfer action.data with
+    | some (_, amount) => amount.val < bn254ScalarModulus
+    | none => true
+  let groupNames :=
+    context.groups.map Prod.fst ++ destinationGroupNames rule.destination ++
+      signerGroupNames rule.signer
+  let allowlistNames :=
+    context.allowlists.map Prod.fst ++ destinationAllowlistNames rule.destination
+  action.data.length <= 256 &&
+  authentication.slots.length <= 5 &&
+  rule.wellFormed &&
+  context.wellFormed &&
+  groupEntries <= 5 && allowlistEntries <= 5 &&
+  rule.id < 2 ^ 32 && thresholdFits &&
+  action.value.val < bn254ScalarModulus && erc20AmountFits &&
+  action.nonce.val == 0 &&
+  collisionFreeNameHashes primitives groupNames &&
+  collisionFreeNameHashes primitives allowlistNames &&
+  (match rule.amountMax with
+   | none => true
+   | some maximum => maximum.val < bn254ScalarModulus)
+
+theorem v2_authenticates_committed_rule (primitives : Primitives) (rule : Rule) :
+    v2Authenticates primitives (v2PolicyCommitment primitives rule) rule = true := by
+  simp [v2Authenticates]
+
+theorem v2_commitment_does_not_bind_rule_id
+    (primitives : Primitives) (rule : Rule) (replacementId : RuleId) :
+    v2PolicyCommitment primitives { rule with id := replacementId } =
+      v2PolicyCommitment primitives rule := by
+  simp [v2PolicyCommitment, v2PolicyPreimage]
+
+theorem v2_preimage_has_fixed_arity (primitives : Primitives) (rule : Rule) :
+    (v2PolicyPreimage primitives rule).length = 14 := by
+  simp [v2PolicyPreimage]
+
+theorem v1_leaf_has_fixed_width (primitives : Primitives) (rule : Rule) :
+    (v1PolicyLeafBytes primitives rule).length = 291 := by
+  simp [v1PolicyLeafBytes, bytes32, bytes20, bytes4, byte1, natToBytesBE]
+
+end ZkGuard.Profiles.Noir

--- a/spec/lean/ZkGuard/Properties.lean
+++ b/spec/lean/ZkGuard/Properties.lean
@@ -1,0 +1,82 @@
+import ZkGuard.Semantics
+
+/-!
+# ZKGuard policy specification: security properties
+-/
+
+namespace ZkGuard
+
+theorem empty_policy_denies
+    (context : Context) (action : Action) (authentication : Authentication) :
+    evaluate ⟨[]⟩ context action authentication = .deny := by
+  rfl
+
+theorem malformed_policy_denies
+    (policy : Policy) (context : Context) (action : Action)
+    (authentication : Authentication) (h : policy.wellFormed = false) :
+    evaluate policy context action authentication = .deny := by
+  simp [evaluate, h]
+
+theorem malformed_context_rejects_rule
+    (rule : Rule) (context : Context) (action : Action)
+    (authentication : Authentication) (h : context.wellFormed = false) :
+    rule.complies context action authentication = false := by
+  simp [Rule.complies, h]
+
+theorem evaluateRules_allows_only_compliant_rule
+    (rules : List Rule) (context : Context) (action : Action)
+    (authentication : Authentication) (ruleId : RuleId)
+    (h : evaluateRules rules context action authentication = .allow ruleId) :
+    ∃ rule ∈ rules, rule.id = ruleId ∧ rule.complies context action authentication = true := by
+  induction rules with
+  | nil => simp [evaluateRules] at h
+  | cons rule rest ih =>
+      by_cases hc : rule.complies context action authentication = true
+      · simp [evaluateRules, hc] at h
+        subst ruleId
+        exact ⟨rule, by simp, rfl, hc⟩
+      · have hc' : rule.complies context action authentication = false := by
+          cases hv : rule.complies context action authentication <;> simp_all
+        simp [evaluateRules, hc'] at h
+        obtain ⟨found, hmem, hid, hcomplies⟩ := ih h
+        exact ⟨found, by simp [hmem], hid, hcomplies⟩
+
+theorem allow_implies_policy_member_complies
+    (policy : Policy) (context : Context) (action : Action)
+    (authentication : Authentication) (ruleId : RuleId)
+    (h : evaluate policy context action authentication = .allow ruleId) :
+    ∃ rule ∈ policy.rules,
+      rule.id = ruleId ∧ rule.complies context action authentication = true := by
+  unfold evaluate at h
+  split at h
+  · exact evaluateRules_allows_only_compliant_rule _ _ _ _ _ h
+  · simp at h
+
+theorem duplicate_authenticated_signer_is_counted_once (signer : Address) :
+    uniqueAddresses [signer, signer] = [signer] := by
+  simp [uniqueAddresses, insertUnique]
+
+theorem zero_threshold_rule_is_not_well_formed
+    (id : RuleId) (txType : TxType) (destination : DestinationPattern)
+    (group : SetName) (asset : AssetPattern) (amountMax : Option Amount)
+    (selector : Option Selector) :
+    (Rule.mk id txType destination (.threshold group 0) asset amountMax selector).wellFormed = false := by
+  simp [Rule.wellFormed]
+
+theorem exact_signer_requires_one_authenticated_slot
+    (context : Context) (action : Action) (required other : Address) (h : other ≠ required) :
+    signerMatches context action (.exact required)
+      (.forAction action [.valid other]) = false := by
+  simp [signerMatches, signerPatternMatches, Authentication.forAction, h]
+
+theorem invalid_signature_does_not_satisfy_any_signer (context : Context) (action : Action) :
+    signerMatches context action .any (.forAction action [.invalid]) = false := by
+  simp [signerMatches, signerPatternMatches, Authentication.forAction, authenticatedSigners]
+
+theorem authentication_is_bound_to_action
+    (context : Context) (action otherAction : Action) (pattern : SignerPattern)
+    (slots : List AuthSlot) (h : otherAction ≠ action) :
+    signerMatches context action pattern (.forAction otherAction slots) = false := by
+  simp [signerMatches, Authentication.forAction, h]
+
+end ZkGuard

--- a/spec/lean/ZkGuard/Semantics.lean
+++ b/spec/lean/ZkGuard/Semantics.lean
@@ -1,0 +1,211 @@
+import ZkGuard.Types
+
+/-!
+# ZKGuard policy specification: executable semantics
+
+This module is the proving-system-independent policy compliance algorithm.
+Malformed policies and malformed actions fail closed.
+-/
+
+namespace ZkGuard
+
+def natToBytesBE (width n : Nat) : List Byte :=
+  (List.range width).map fun i =>
+    ⟨(n / (256 ^ (width - 1 - i))) % 256, Nat.mod_lt _ (by decide)⟩
+
+def bytesToNatBE (bytes : List Byte) : Nat :=
+  bytes.foldl (fun acc byte => acc * 256 + byte.val) 0
+
+def addressOfBytes (bytes : List Byte) : Address :=
+  ⟨bytesToNatBE bytes % (2 ^ 160), Nat.mod_lt _ (by decide)⟩
+
+def selectorOfBytes (bytes : List Byte) : Selector :=
+  ⟨bytesToNatBE bytes % (2 ^ 32), Nat.mod_lt _ (by decide)⟩
+
+def amountOfBytes (bytes : List Byte) : Amount :=
+  ⟨bytesToNatBE bytes % (2 ^ 256), Nat.mod_lt _ (by decide)⟩
+
+def transferSelector : Selector := ⟨0xa9059cbb, by decide⟩
+
+def hasTransferSelector (data : List Byte) : Bool :=
+  data.length >= 4 && selectorOfBytes (data.take 4) == transferSelector
+
+def parseErc20Transfer (data : List Byte) : Option (Address × Amount) :=
+  if data.length < 68 then
+    none
+  else
+    some
+      (addressOfBytes ((data.drop 16).take 20),
+       amountOfBytes ((data.drop 36).take 32))
+
+/- Classification is strict about native value combined with calldata. Such an
+action is neither a plain native transfer nor an unambiguous zero-value call.
+-/
+def classify (action : Action) : Except ClassificationError ClassifiedAction :=
+  if action.value.val > 0 then
+    if action.data.isEmpty then
+      .ok {
+        txType := .transfer
+        destination := action.to
+        asset := zeroAddress
+        amount := action.value
+      }
+    else
+      .error .nativeValueWithCalldata
+  else if hasTransferSelector action.data then
+    match parseErc20Transfer action.data with
+    | some (recipient, amount) =>
+        .ok {
+          txType := .transfer
+          destination := recipient
+          asset := action.to
+          amount
+        }
+    | none => .error .malformedErc20Transfer
+  else
+    .ok {
+      txType := .contractCall
+      destination := action.to
+      asset := zeroAddress
+      amount := 0
+    }
+
+def AddressBook.lookup : AddressBook → SetName → Option (List Address)
+  | [], _ => none
+  | (entryName, members) :: rest, name =>
+      if entryName == name then some members else lookup rest name
+
+def AddressBook.member (book : AddressBook) (name : SetName) (address : Address) : Bool :=
+  match book.lookup name with
+  | none => false
+  | some members => members.contains address
+
+def uniqueSetNames : AddressBook → Bool
+  | [] => true
+  | (name, _) :: rest =>
+      !(rest.any fun entry => entry.1 == name) && uniqueSetNames rest
+
+def AddressBook.wellFormed (book : AddressBook) : Bool := uniqueSetNames book
+
+def Context.wellFormed (context : Context) : Bool :=
+  context.groups.wellFormed && context.allowlists.wellFormed
+
+def destinationMatches
+    (context : Context) (pattern : DestinationPattern) (address : Address) : Bool :=
+  match pattern with
+  | .any => true
+  | .exact required => address == required
+  | .group name => context.groups.member name address
+  | .allowlist name => context.allowlists.member name address
+
+def authenticatedSigners : List AuthSlot → List Address
+  | [] => []
+  | .invalid :: rest => authenticatedSigners rest
+  | .valid signer :: rest => signer :: authenticatedSigners rest
+
+def insertUnique (address : Address) : List Address → List Address
+  | [] => [address]
+  | head :: tail =>
+      if address == head then head :: tail else head :: insertUnique address tail
+
+def uniqueAddresses : List Address → List Address
+  | [] => []
+  | head :: tail => insertUnique head (uniqueAddresses tail)
+
+def uniqueAuthenticatedGroupMembers
+    (context : Context) (group : SetName) (authentication : Authentication) : List Address :=
+  uniqueAddresses <|
+    (authenticatedSigners authentication.slots).filter fun signer =>
+      context.groups.member group signer
+
+def signerPatternMatches
+    (context : Context) (pattern : SignerPattern) (authentication : Authentication) : Bool :=
+  match pattern with
+  | .any => (authenticatedSigners authentication.slots).isEmpty == false
+  | .exact required => decide (authentication.slots = [.valid required])
+  | .group name =>
+      match authentication.slots with
+      | [.valid signer] => context.groups.member name signer
+      | _ => false
+  | .threshold group required =>
+      (uniqueAuthenticatedGroupMembers context group authentication).length >= required
+
+def signerMatches
+    (context : Context) (action : Action) (pattern : SignerPattern)
+    (authentication : Authentication) : Bool :=
+  decide (authentication.action = action) &&
+    signerPatternMatches context pattern authentication
+
+def assetMatches (pattern : AssetPattern) (asset : Address) : Bool :=
+  match pattern with
+  | .any => true
+  | .exact required => asset == required
+
+def selectorMatches (expected : Option Selector) (data : List Byte) : Bool :=
+  match expected with
+  | none => true
+  | some selector => data.length >= 4 && selectorOfBytes (data.take 4) == selector
+
+def Rule.wellFormed (rule : Rule) : Bool :=
+  let signerValid :=
+    match rule.signer with
+    | .threshold _ required => required > 0
+    | _ => true
+  let shapeValid :=
+    match rule.txType with
+    | .transfer => rule.functionSelector.isNone
+    | .contractCall => rule.amountMax.isNone && rule.asset == .any
+  signerValid && shapeValid
+
+def Rule.complies
+    (rule : Rule) (context : Context) (action : Action)
+    (authentication : Authentication) : Bool :=
+  if !rule.wellFormed || !context.wellFormed then
+    false
+  else
+    match classify action with
+    | .error _ => false
+    | .ok classified =>
+        let amountMatches :=
+          match classified.txType, rule.amountMax with
+          | .transfer, some maximum => classified.amount.val <= maximum.val
+          | _, _ => true
+        let functionMatches :=
+          match classified.txType with
+          | .contractCall => selectorMatches rule.functionSelector action.data
+          | .transfer => true
+        rule.txType == classified.txType &&
+        destinationMatches context rule.destination classified.destination &&
+        signerMatches context action rule.signer authentication &&
+        assetMatches rule.asset classified.asset &&
+        amountMatches &&
+        functionMatches
+
+def uniqueRuleIds : List Rule → Bool
+  | [] => true
+  | rule :: rest =>
+      !(rest.any fun candidate => candidate.id == rule.id) && uniqueRuleIds rest
+
+def Policy.wellFormed (policy : Policy) : Bool :=
+  policy.rules.all Rule.wellFormed && uniqueRuleIds policy.rules
+
+def evaluateRules
+    (rules : List Rule) (context : Context) (action : Action)
+    (authentication : Authentication) : Decision :=
+  match rules with
+  | [] => .deny
+  | rule :: rest =>
+      if rule.complies context action authentication then
+        .allow rule.id
+      else
+        evaluateRules rest context action authentication
+
+def evaluate
+    (policy : Policy) (context : Context) (action : Action)
+    (authentication : Authentication) : Decision :=
+  if policy.wellFormed then
+    evaluateRules policy.rules context action authentication
+  else
+    .deny
+
+end ZkGuard

--- a/spec/lean/ZkGuard/Types.lean
+++ b/spec/lean/ZkGuard/Types.lean
@@ -1,0 +1,108 @@
+/-!
+# ZKGuard policy specification: domain types
+
+These types are the semantic boundary of the policy engine. Cryptographic
+authentication produces `AuthSlot.valid signer`; the policy evaluator never
+trusts an unauthenticated address supplied by a prover.
+-/
+
+namespace ZkGuard
+
+abbrev Byte := Fin 256
+abbrev Address := Fin (2 ^ 160)
+abbrev Selector := Fin (2 ^ 32)
+abbrev Amount := Fin (2 ^ 256)
+abbrev Nonce := Fin (2 ^ 64)
+abbrev RuleId := Nat
+abbrev SetName := String
+
+def zeroAddress : Address := 0
+
+inductive TxType where
+  | transfer
+  | contractCall
+  deriving Repr, DecidableEq, BEq
+
+inductive DestinationPattern where
+  | any
+  | exact (address : Address)
+  | group (name : SetName)
+  | allowlist (name : SetName)
+  deriving Repr, DecidableEq, BEq
+
+inductive SignerPattern where
+  | any
+  | exact (address : Address)
+  | group (name : SetName)
+  | threshold (group : SetName) (required : Nat)
+  deriving Repr, DecidableEq, BEq
+
+inductive AssetPattern where
+  | any
+  | exact (address : Address)
+  deriving Repr, DecidableEq, BEq
+
+structure Rule where
+  id : RuleId
+  txType : TxType
+  destination : DestinationPattern
+  signer : SignerPattern
+  asset : AssetPattern
+  amountMax : Option Amount
+  functionSelector : Option Selector
+  deriving Repr, DecidableEq, BEq
+
+structure Action where
+  initiator : Address
+  to : Address
+  value : Amount
+  nonce : Nonce
+  data : List Byte
+  deriving Repr, DecidableEq, BEq
+
+/- `invalid` means that a submitted signature did not authenticate. A valid
+slot contains the address derived from a successfully verified public key.
+Keeping slots, rather than only a set of addresses, preserves exact-one rules.
+-/
+inductive AuthSlot where
+  | invalid
+  | valid (signer : Address)
+  deriving Repr, DecidableEq, BEq
+
+structure Authentication where
+  action : Action
+  slots : List AuthSlot
+  deriving Repr, DecidableEq, BEq
+
+def Authentication.forAction (action : Action) (slots : List AuthSlot) : Authentication :=
+  { action, slots }
+
+abbrev AddressBook := List (SetName × List Address)
+
+structure Context where
+  groups : AddressBook
+  allowlists : AddressBook
+  deriving Repr, DecidableEq, BEq
+
+structure ClassifiedAction where
+  txType : TxType
+  destination : Address
+  asset : Address
+  amount : Amount
+  deriving Repr, DecidableEq, BEq
+
+inductive ClassificationError where
+  | nativeValueWithCalldata
+  | malformedErc20Transfer
+  deriving Repr, DecidableEq, BEq
+
+inductive Decision where
+  | allow (ruleId : RuleId)
+  | deny
+  deriving Repr, DecidableEq, BEq
+
+structure Policy where
+  rules : List Rule
+  deriving Repr, DecidableEq, BEq
+
+end ZkGuard

--- a/spec/lean/lake-manifest.json
+++ b/spec/lean/lake-manifest.json
@@ -1,0 +1,5 @@
+{"version": "1.1.0",
+ "packagesDir": ".lake/packages",
+ "packages": [],
+ "name": "zkguardSpec",
+ "lakeDir": ".lake"}

--- a/spec/lean/lakefile.lean
+++ b/spec/lean/lakefile.lean
@@ -1,0 +1,8 @@
+import Lake
+
+open Lake DSL
+
+package zkguardSpec where
+  buildDir := "../../.cache/lean-lake-build"
+
+lean_lib ZkGuard

--- a/spec/lean/lean-toolchain
+++ b/spec/lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.19.0


### PR DESCRIPTION
Adds the typed, executable Lean specification as a stacked follow-up to #16.

Scope:
- Proving-system-independent policy domain types and executable compliance semantics.
- Fail-closed security properties and representative executable examples.
- Noir V1/V2 canonical encoding and rule-authentication profiles.
- Canonical V1 Merkle index checks and Noir compatibility constraints.
- Pinned Lean 4.19.0 toolchain and a dedicated `lake build` CI job.

Validation:
- `lake build` passes.
- No `sorry`, `admit`, or custom axioms.
- Independent compact-context review of the combined runtime/spec work returned `ship`.

This PR intentionally does not claim compiled ACIR equivalence. That bridge remains future work using Lean-generated conformance vectors and differential execution.

Stacking:
- Base is #16 so this PR contains only the Lean specification.
- After #16 merges, this PR can be retargeted to `main`.